### PR TITLE
Refactor answers, fixes #5

### DIFF
--- a/lib/csa/ccm/answer.rb
+++ b/lib/csa/ccm/answer.rb
@@ -23,10 +23,12 @@ class Answer
     question_id <=> other.question_id
   end
 
-  def to_hash(skip_comment)
-    ATTRIBS.inject({}) do |acc, attrib|
+  def to_hash(skip_comment = true)
+    attribs = skip_comment ? ATTRIBS - [:comment] : ATTRIBS
+
+    attribs.inject({}) do |acc, attrib|
       value = send(attrib)
-      if value.nil? || (attrib == :comment && skip_comment)
+      if value.nil?
         acc
       else
         acc.merge(attrib.to_s.tr('_', '-') => value)

--- a/lib/csa/ccm/answers.rb
+++ b/lib/csa/ccm/answers.rb
@@ -1,6 +1,3 @@
-require_relative 'control_domain'
-require_relative 'control'
-require_relative 'question'
 require_relative 'answer'
 
 module Csa::Ccm
@@ -18,52 +15,35 @@ class Answers
       send("#{k}=", v)
     end
 
-    if @source_path
-      ccm = YAML.safe_load(File.read(@source_path, encoding: 'UTF-8'))['ccm']
-      @answers = ccm['answers'].map { |a| [a['question-id'], Answer.new(a)] }.to_h
-      @metadata ||= ccm['metadata']
-      @version ||= @metadata['version']
-    end
-
     @answers ||= {}
 
     self
+  end
+
+  def self.from_yaml(filename)
+    ccm = YAML.safe_load(File.read(filename, encoding: 'UTF-8'))['ccm']
+    answers = ccm['answers'].map { |a| [a['question-id'], Answer.new(a)] }.to_h
+    metadata = ccm['metadata']
+    version = metadata['version']
+
+    self.new(
+      answers: answers,
+      metadata: metadata,
+      version: version,
+      source_path: filename
+    )
   end
 
   def <<(answer)
     @answers[answer.question_id] = answer
   end
 
-  def apply_to(matrix)
-    worksheet = matrix.worksheet
-    all_rows = worksheet.sheet_data.rows
-
-    start_row = matrix.get_start_row(matrix.version)
-    max_row_number = all_rows.length - 1
-
-    (start_row..max_row_number).each do |row_number|
-      question_id = worksheet[row_number][2].value
-
-      next unless @answers.key?(question_id)
-
-      answer = @answers[question_id]
-
-      answer_col = case answer.answer
-                   when 'yes', true
-                     5
-                   when 'no', false
-                     6
-                   when 'NA'
-                     7
-                   end
-
-      worksheet[row_number][answer_col].change_contents(answer.comment)
-    end
-
-    matrix
+  # TODO: This will go away if we inherit directly from Hash
+  def [](question_id)
+    @answers[question_id]
   end
 
-  def to_hash(skip_comment)
+  def to_hash(skip_comment = true)
     {
       'ccm' => {
         'metadata' => @metadata.to_hash,
@@ -72,9 +52,13 @@ class Answers
     }
   end
 
-  def to_file(filename, skip_comment)
+  def to_yaml(skip_comment = true)
+    to_hash(skip_comment).to_yaml
+  end
+
+  def to_file(filename, skip_comment = true)
     File.open(filename, 'w') do |file|
-      file.write(to_hash(skip_comment).to_yaml)
+      file.write(to_yaml)
     end
   end
 end

--- a/lib/csa/ccm/cli/command.rb
+++ b/lib/csa/ccm/cli/command.rb
@@ -62,7 +62,9 @@ module Csa
 
           matrix = Matrix.from_xlsx(input_xlsx_file)
 
-          base_output_file = options[:output_name] || File.basename(input_xlsx_file.gsub('.xlsx', ''))
+          base_output_file = options[:output_name] ||
+            File.basename(input_xlsx_file.gsub('.xlsx', ''))
+
           if options[:output_path]
             base_output_file = File.join(options[:output_path], base_output_file)
           end
@@ -123,15 +125,11 @@ module Csa
             output_file = answers_yaml_path.gsub('.yaml', '.xlsx')
           end
 
-          answers = Answers.new(source_path: answers_yaml_path)
+          answers = Answers.from_yaml(answers_yaml_path)
           matrix = Matrix.new(source_path: template_xslt_path)
 
-          unless matrix.version == answers.version
-            raise "Template XLSX & answers YAML version missmatch #{matrix.version} vs. #{answers.version}"
-          end
-
-          answers.apply_to(matrix)
-          matrix.workbook.write(output_file)
+          matrix.apply_answers(answers)
+          matrix.to_xlsx(output_file)
         end
       end
     end

--- a/lib/csa/ccm/control.rb
+++ b/lib/csa/ccm/control.rb
@@ -34,9 +34,13 @@ class Control
     end
   end
 
+  def to_yaml
+    to_hash.to_yaml
+  end
+
   def to_file(filename)
     File.open(filename,"w") do |file|
-      file.write(to_hash.to_yaml)
+      file.write(to_yaml)
     end
   end
 

--- a/lib/csa/ccm/control_domain.rb
+++ b/lib/csa/ccm/control_domain.rb
@@ -35,9 +35,13 @@ class ControlDomain
     end
   end
 
+  def to_yaml
+    to_hash.to_yaml
+  end
+
   def to_file(filename)
     File.open(filename, "w") do |file|
-      file.write(to_hash.to_yaml)
+      file.write(to_yaml)
     end
   end
 

--- a/lib/csa/ccm/matrix_row.rb
+++ b/lib/csa/ccm/matrix_row.rb
@@ -1,0 +1,62 @@
+module Csa::Ccm
+
+  class MatrixRow
+
+    ATTRIBS = %i[
+      control_domain_id control_id question_id control_spec
+      question_content answer_yes answer_no answer_na comment
+      control_domain_description
+    ].freeze
+
+    attr_accessor *ATTRIBS
+
+    def initialize(ruby_xl_row)
+      @control_domain_description = ruby_xl_row[0].value
+      @control_id = ruby_xl_row[1].value
+      @question_id = ruby_xl_row[2].value
+      @control_spec = ruby_xl_row[3].value
+      @question_content = ruby_xl_row[4].value
+      @answer_yes = ruby_xl_row[5].value
+      @answer_no = ruby_xl_row[6].value
+      @answer_na = ruby_xl_row[7].value
+      @comment = ruby_xl_row[8].value
+
+      # In 3.0.1 2017-09-01, question_id for "AIS-02.2" is listed as "AIS- 02.2"
+      %w[control_id question_id].each do |field|
+        if val = send(field)
+          send("#{field}=", val.gsub(/\s/, ''))
+        end
+      end
+
+      # In 3.0.1 2017-09-01, Rows 276 and 277's control ID says "LG-02" but it should be "STA-05" instead.
+      if @control_id.nil? && @question_id
+        @control_id = @question_id.split('.').first
+      end
+
+      @control_domain_id = control_id.split('-').first if @control_id
+
+      # puts "HERE IN ROW! #{ruby_xl_row.cells.map(&:value)}"
+
+      # puts control_domain_description
+      # puts control_id
+      # puts question_id
+
+      self
+    end
+
+    def control_domain_title
+      return nil if control_domain_description.nil?
+
+      name, = control_domain_description.split(/(\n)/)
+      name
+    end
+
+    def control_title
+      return nil if control_domain_description.nil?
+
+      _, _, control_title = control_domain_description.split(/(\n)/)
+      control_title
+    end
+
+  end
+end


### PR DESCRIPTION
Following up on #14.

The logic should be:
```
Answers data + Matrix data => filled Matrix => Excel file.
```

This PR moves `Answers` class `apply_to(matrix)` into the `Matrix` class.

Reason: The `Answers` class should not know about internals of the `Matrix`, e.g. `matrix.worksheet`.
