### PR TITLE
gemspec: pin required_ruby_version >= 3.3.0 + bump rubocop TargetRubyVersion to 3.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,4 +7,4 @@ inherit_from:
 # ...
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.3

--- a/csa-ccm.gemspec
+++ b/csa-ccm.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 3.3.0"
+
   spec.add_runtime_dependency "rake"
   spec.add_runtime_dependency "rubyXL", "~> 3.4"
   spec.add_runtime_dependency "thor", "~> 1.0"


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/274

## Summary

Adds the missing `required_ruby_version = ">= 3.3.0"` to `csa-ccm.gemspec` and bumps `.rubocop.yml`'s `TargetRubyVersion` from `2.5` to `3.3` to match.

This closes the last remaining NOVER edge case from the `metanorma/ci#274` (Raise minimum Ruby version to 3.3) dry-run preview. Per the [2026-06-29 triage finding](https://github.com/metanorma/ci/issues/274) on `#274`'s MISSING/NOVER set: `csa-ccm.gemspec` uses the standard `Gem::Specification.new do |spec|` shape (so the `(spec|s)` patches regex relaxed in [`metanorma/ci#324`](https://github.com/metanorma/ci/pull/324) would match it correctly), but the file has **no `required_ruby_version` line at all**. The cimas-side `patches: ruby_version` mechanism is a *replace* operation — it can't insert when the target line is absent.

So per-flavour-gemspec hygiene is the cleanest path: add the line directly at the source, same shape as the `#210` close-at-source recommendation.

## What changed

`csa-ccm.gemspec`:

```diff
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

+  spec.required_ruby_version = ">= 3.3.0"
+
   spec.add_runtime_dependency "rake"
```

`.rubocop.yml`:

```diff
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.3
```

Rubocop's `Gemspec/RequiredRubyVersion` cop requires `required_ruby_version` and `TargetRubyVersion` to be equal; the previous `2.5` was stale (Ruby 2.5 EOLed 2018-03-31). Both now consistent at 3.3.

## Verification

- `ruby -c csa-ccm.gemspec` passes.
- `.rubocop.yml`'s `TargetRubyVersion: 3.3` matches `required_ruby_version: >= 3.3.0` (Rubocop's `Gemspec/RequiredRubyVersion` consistency check satisfied).
- No version bump — this is gemspec-metadata-only, not a release-triggering change.

## Net effect on `#274`

The `#274` dry-run preview's NOVER set was the single `csa-ccm-tools/csa-ccm.gemspec` instance. After this PR merges, the `#274` "MISSING + NOVER" set from the 2026-06-29 triage is fully resolved at the cimas-config / per-repo-hygiene layer.

🤖
